### PR TITLE
fix svelte.technology/guide redirect

### DIFF
--- a/svelte.technology/index.js
+++ b/svelte.technology/index.js
@@ -3,9 +3,7 @@ const http = require('http');
 const dest = `https://svelte.dev`;
 
 const server = http.createServer((req, res) => {
-	const url = req.url.startsWith('guide')
-		? 'docs'
-		: req.url;
+	const url = req.url === '/guide' ? '/docs' : req.url;
 
 	res.writeHead(301, {
 		'Location': `${dest}${url}`


### PR DESCRIPTION
The startsWith check wasn't working because it missed the leading forward slash. I also don't think it actually has to worry about checking for startsWith, because hash fragments aren't part of the URL sent to the browser.